### PR TITLE
Typo/style fixes.

### DIFF
--- a/basics/equality.md
+++ b/basics/equality.md
@@ -2,17 +2,16 @@
 
 Programmers frequently need to determine the equality of variables in relation to other variables. This is done using an equality operator.
 
-The most basic equality operator is the `==` operator. This operator does everything it can to make determine if two variables are equal, even if they are not of the same type. 
+The most basic equality operator is the `==` operator. This operator does everything it can to determine if two variables are equal, even if they are not of the same type. 
 
-For example, assume
-```
+For example, assume:
+```javascript
 var foo = 42;
 var bar = 42;
 var baz = "42";
 var qux = "life";
 ```
-.
 
-`foo == bar` will evaluate to `true` and `baz == qux` will evaluate to false, as one would expect. However, `foo == baz` will *also* evaluate to `true` despite `foo` and `baz` being different types. Behind the scenes the `==` equality operator attempts to force its operands to the same type before determining their equality. This is in contrast to the `===` equality operator.
+`foo == bar` will evaluate to `true` and `baz == qux` will evaluate to `false`, as one would expect. However, `foo == baz` will *also* evaluate to `true` despite `foo` and `baz` being different types. Behind the scenes the `==` equality operator attempts to force its operands to the same type before determining their equality. This is in contrast to the `===` equality operator.
 
 The `===` equality operator determines that two variables are equal if they are of the same type *and* have the same value. With the same assumptions as before, this means that `foo === bar` will still evaluate to `true`,  but `foo === baz` will now evaluate to `false`. `baz === qux` will still evaluate to `false`.


### PR DESCRIPTION
Fixed typo in first sentence describing how == works. Set syntax highlighting to Javascript mode. Added missing highlight to an occurrence of 'false'. Removed effectively superflous '.' around the big code block.
