### PR TITLE
Remove backticks around "override"

### DIFF
--- a/objects/prototype.md
+++ b/objects/prototype.md
@@ -15,7 +15,7 @@ var stringRepresentation = adult.toString();
  // the variable has value of '[object Object]'
 ```
 
-`toString` is an Object.prototype's property, which was inhereted. It has a value of a function, which returns a string representation of the object. If you want it to return a more meaningful representation, then you can `override` it. Simply add a new property to the adult object.
+`toString` is an Object.prototype's property, which was inhereted. It has a value of a function, which returns a string representation of the object. If you want it to return a more meaningful representation, then you can override it. Simply add a new property to the adult object.
 
 ```js
 adult.toString = function(){


### PR DESCRIPTION
This is a straightforward fix to eliminate any confusion that "override" might be a JavaScript keyword. Words rendered as code imply they are either a variable name or a reserved word. In this case, "override" is intended merely to convey its plain English meaning, and so should not be rendered as code.
