### PR TITLE
Update getAuthorFullName function to include space

### DIFF
--- a/objects/properties.md
+++ b/objects/properties.md
@@ -11,7 +11,7 @@ var language = {
     },
  // Yes, objects can be nested!
     getAuthorFullName: function(){
-        return this.author.firstName + this.author.lastName;    
+        return this.author.firstName + " " + this.author.lastName;    
     }
  // Yes, functions can be values too!
 };


### PR DESCRIPTION
Add space between first and last name to match format as taught in "Strings - Concatenation" chapter, and for readability

Here is the [exercise from the Concatenation section](https://github.com/GitbookIO/javascript/commit/5bfd4cbaec436b44b32d2d8b54e9b0b837672209#diff-f8878daa61e33da02738b3b427a48525R24) for reference: `var fullName = firstName + " " + lastName;`
